### PR TITLE
Add user and thread context to chat logs

### DIFF
--- a/src/run_service.py
+++ b/src/run_service.py
@@ -1,6 +1,6 @@
 import asyncio
-import sys
 import logging
+import sys
 
 import uvicorn
 from dotenv import load_dotenv
@@ -8,7 +8,23 @@ from dotenv import load_dotenv
 from core import settings
 
 load_dotenv()
-logging.basicConfig(level=logging.INFO)
+
+# Ensure custom fields are always present in LogRecord
+old_factory = logging.getLogRecordFactory()
+
+
+def record_factory(*args, **kwargs):
+    record = old_factory(*args, **kwargs)
+    record.user_id = getattr(record, "user_id", "-")
+    record.thread_id = getattr(record, "thread_id", "-")
+    return record
+
+
+logging.setLogRecordFactory(record_factory)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - [user_id=%(user_id)s thread_id=%(thread_id)s] %(message)s",
+)
 
 if __name__ == "__main__":
     # Set Compatible event loop policy on Windows Systems.

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -177,11 +177,10 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatRe
     agent: Pregel = get_agent(agent_id)
     kwargs, run_id, thread_id, user_id = await _handle_input(user_input, agent)
     logger.info(
-        "User message for %s [user_id=%s thread_id=%s]: %s",
+        "User message for %s: %s",
         agent_id,
-        user_id,
-        thread_id,
         user_input.message,
+        extra={"user_id": user_id, "thread_id": thread_id},
     )
 
     try:
@@ -197,11 +196,10 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatRe
             raise ValueError(f"Unexpected response type: {response_type}")
 
         logger.info(
-            "Agent %s response [user_id=%s thread_id=%s]: %s",
+            "Agent %s response: %s",
             agent_id,
-            user_id,
-            thread_id,
             output.content,
+            extra={"user_id": user_id, "thread_id": thread_id},
         )
         output.run_id = str(run_id)
         return ChatResponse(status="success", data=output)
@@ -221,11 +219,10 @@ async def message_generator(
     agent: Pregel = get_agent(agent_id)
     kwargs, run_id, thread_id, user_id = await _handle_input(user_input, agent)
     logger.info(
-        "User message for %s [user_id=%s thread_id=%s]: %s",
+        "User message for %s: %s",
         agent_id,
-        user_id,
-        thread_id,
         user_input.message,
+        extra={"user_id": user_id, "thread_id": thread_id},
     )
 
     try:
@@ -299,11 +296,10 @@ async def message_generator(
                     == "stop"
                 ):
                     logger.info(
-                        "Agent %s streamed message [user_id=%s thread_id=%s]: %s",
+                        "Agent %s streamed message: %s",
                         agent_id,
-                        user_id,
-                        thread_id,
                         chat_message.content,
+                        extra={"user_id": user_id, "thread_id": thread_id},
                     )
                     yield f"data: {json.dumps({'type': 'message', 'content': chat_message.model_dump()})}\n\n"
                 else:


### PR DESCRIPTION
## Summary
- attach `user_id` and `thread_id` fields to log records
- include those fields when logging user and AI messages

## Testing
- `pre-commit run --files src/run_service.py src/service/service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a42a4d840832aa35a687604fbcb43